### PR TITLE
Modified setup.cfg to include flags for nosetests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,10 @@
 [nosetests]
-verbosity=1
+cover-erase=1
+cover-package=service
+spec-color=1
+verbosity=2
+with-coverage=1
+with-spec=1
 
 [coverage:report]
 show_missing = True


### PR DESCRIPTION
Included various flags for verbosity, colors, and coverage.